### PR TITLE
updated inventory and viewcharacter screen

### DIFF
--- a/src/viewCharacter.cpp
+++ b/src/viewCharacter.cpp
@@ -61,6 +61,16 @@ QMap<QString, int> skillMap =
     {"Survival", 4}
 };
 
+// When we come back to this screen from the inventory or spells screen, we need to reload the character
+void ViewCharacter::loadAll()
+{
+    loadCharacter(name); // Load the character's information
+    evaluateCharacterModifiers(); // Evaluate the character's modifiers
+    loadPicture(QDir::currentPath() + "/data/characters/" + name + "/character.png"); // Load the character's picture
+    loadEquippedItems(); // Load the character's equipped items
+    loadPreppedSpells(); // Load the character's prepped spells
+}
+
 void ViewCharacter::loadCharacter(QString name)
 {
     // Load the character's information, notes, and stats
@@ -336,7 +346,7 @@ void ViewCharacter::loadEquippedItems()
 
         if (equipped)
         {   
-            QListWidgetItem *item = new QListWidgetItem("(x" + QString::number(quantity) + ") " + itemName);
+            QListWidgetItem *item = new QListWidgetItem("(" + QString::number(quantity) + ") " + itemName);
             item->setData(Qt::UserRole, line); // Store full data string in UserRole
             if(attunement)
             {

--- a/src/viewCharacter.h
+++ b/src/viewCharacter.h
@@ -46,6 +46,7 @@ public:
     explicit ViewCharacter(QWidget *parent = 0, QString name = "");
     ~ViewCharacter();
     void printCharacterToConsole();
+    void loadAll();
 
 private:
     void loadCharacter(QString name);

--- a/src/viewInventory.cpp
+++ b/src/viewInventory.cpp
@@ -9,6 +9,7 @@ Last Modified: 12/4/2024
 
 #include "viewInventory.h"
 #include "themeUtils.h"
+#include "viewCharacter.h"
 
 #include <QVBoxLayout>
 #include <QPushButton>
@@ -138,6 +139,7 @@ ViewInventory::ViewInventory(QWidget *parent, QString name) :
     connect(addItemButton, &QPushButton::clicked, this, &ViewInventory::addItem);
     connect(equipItemButton, &QPushButton::clicked, this, &ViewInventory::equipItem);
     connect(attuneItemButton, &QPushButton::clicked, this, &ViewInventory::attuneItem);
+    connect(inventoryList, &QListWidget::itemSelectionChanged, this, [this, equipItemButton, attuneItemButton](){ updateButtons(*equipItemButton, *attuneItemButton); });
 
     reloadTheme(); // Reload the theme after everything is placed
 
@@ -147,8 +149,50 @@ ViewInventory::ViewInventory(QWidget *parent, QString name) :
 
 void ViewInventory::goBack() {
     QStackedWidget *mainStackedWidget = qobject_cast<QStackedWidget *>(this->parentWidget());
-    if (mainStackedWidget) {
-        mainStackedWidget->setCurrentIndex(0); // Switch to CharacterSelect (index 0)
+    if (mainStackedWidget)
+    {
+        // cast the QWidget from index 0
+        QWidget *viewCharacterWidget = mainStackedWidget->widget(0);
+
+        // call the loadAll() function from viewCharacter which is the QWidget at index 0
+        ViewCharacter *character = qobject_cast<ViewCharacter *>(viewCharacterWidget);
+        if (character)
+        {
+            character->loadAll();
+        }
+
+        mainStackedWidget->setCurrentIndex(0); // Switch to ViewCharacter (index 0)
+    }
+}
+
+// Update the equip and attune buttons based on the selected item
+void ViewInventory::updateButtons(QPushButton &equipItemButton, QPushButton &attuneItemButton)
+{
+    // Get the selected item
+    QListWidgetItem *item = inventoryList->currentItem();
+    if (!item) return; // Return if no item is selected
+
+    QStringList fields = item->data(Qt::UserRole).toString().split(","); // Split the data string
+    if (fields.size() < 4) return; // Return if the data is invalid
+
+    int equipped = fields[2].toInt(); // Get the equipped value
+    int attunement = fields[3].toInt(); // Get the attunement value
+
+    if(equipped == 1) // If the item is equipped, change text to "Unequip Item"
+    {
+        equipItemButton.setText("Unequip Item");
+    }
+    else // Otherwise, change text to "Equip Item"
+    {
+        equipItemButton.setText("Equip Item");
+    }
+    if(attunement == 1) // If the item is attuned, change text to "Unattune Item"
+    {
+        attuneItemButton.setText("Unattune Item");
+    }
+    else // Otherwise, change text to "Attune Item"
+    {
+        attuneItemButton.setText("Attune Item");
     }
 }
 

--- a/src/viewInventory.h
+++ b/src/viewInventory.h
@@ -13,6 +13,7 @@ Last Modified: 12/4/2024
 #include <QWidget>
 #include <QListWidget>
 #include <QLabel>
+#include <QPushButton>
 
 class ViewInventory : public QWidget
 {
@@ -35,6 +36,7 @@ private slots:
     void addItem(); // Add a new item to the inventory
     void equipItem(); // Equip the selected item
     void attuneItem(); // Attune the selected item
+    void updateButtons(QPushButton &equipItemButton, QPushButton &attuneItemButton); // Update button states based on selected item
 };
 
 #endif


### PR DESCRIPTION
update inventory buttons based on selected items equipped and attuned status added a function in viewcharacter to reload all of the information. it gets called once we return to the screen from viewinventory or viewspells so that it can update the equipped items list and the prepped spells list.